### PR TITLE
Modest attempt to make push bundle re-entrant

### DIFF
--- a/src/lib/HgRunner.php
+++ b/src/lib/HgRunner.php
@@ -55,7 +55,9 @@ class HgRunner {
         $cmd = "hg incoming $filepath";
         $this->logEvent("cmd: $cmd");
         $asyncRunner = new AsyncRunner($filepath . '.incoming');
-        $asyncRunner->run($cmd);
+        if (!$asyncRunner->isRunning()) {
+            $asyncRunner->run($cmd);
+        }
         $asyncRunner->synchronize();
         $output = $asyncRunner->getOutput();
         if (preg_match('/abort:.*unknown parent/', $output)) {


### PR DESCRIPTION
- In the event that unbundle takes too long we return a code that allows
  the client to continue. Therefore push bundle needs to be re-entrant,
  requiring that the async runner be checked to see if it is already
  running before execution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hgresume/4)
<!-- Reviewable:end -->
