### PR TITLE
Force creation of v1 bundles

### DIFF
--- a/api/src/HgRunner.php
+++ b/api/src/HgRunner.php
@@ -114,6 +114,7 @@ class HgRunner {
 			}
 			$cmd .= $bundleFilePath;
 		}
+		$cmd .= " -t v1";
 		$asyncRunner = new AsyncRunner($bundleFilePath);
 		$asyncRunner->run($cmd);
 		return $asyncRunner;


### PR DESCRIPTION
Mercurial 3.5 and later defaults to creating v2 bundles for new projects (existing projects will continue to use v1 bundles by default), which Mercurial 3.3 (deployed in current versions of Chorus) doesn't understand. The -t option forces creation of v1 bundles.

See https://www.mercurial-scm.org/doc/hg.1.html#bundle and https://www.mercurial-scm.org/wiki/BundleFormat2 for more details

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hgresume/5)
<!-- Reviewable:end -->
