### PR TITLE
Send correct MIME type for Mercurial bundles

### DIFF
--- a/api/src/RestServer.php
+++ b/api/src/RestServer.php
@@ -88,6 +88,7 @@ class RestServer {
 
 		if (!$debug) {
 			// regular mode
+			header("Content-Type: application/octet-stream");
 			foreach ($headers as $header) {
 				header($header);
 			}


### PR DESCRIPTION
PHP defaults to `text/html` content type if none is specified, and that is causing issues when this API endpoint is behind CloudFlare (which uses the `text/html` content type as a heuristic to apply caching rules that are inappropriate for the responses from Resumable). By setting the content type correctly to `application/octet-stream`, Chorus Send/Receive works correctly with Resumable behind CloudFlare (tested on FLEx 8.3 on Windows 10).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hgresume/7)
<!-- Reviewable:end -->
