### PR TITLE
Bug/fix long pushes end up in invalid state

### DIFF
--- a/api/src/AsyncRunner.php
+++ b/api/src/AsyncRunner.php
@@ -67,7 +67,7 @@ class AsyncRunner
 	 * Waits for up to 5s for the runner to complete
 	 * @return boolean	True if complete, otherwise not complete yet
 	 */
-	public function synchronize() {
+	public function waitForIsComplete() {
 		for ($i = 0; $i < 5; $i++) {
 			if ($this->isComplete()) {
 				return true;

--- a/api/src/AsyncRunner.php
+++ b/api/src/AsyncRunner.php
@@ -64,17 +64,17 @@ class AsyncRunner
 	}
 
 	/**
-	 * 
-	 * @throws AsyncRunnerException
+	 * Waits for up to 5s for the runner to complete
+	 * @return boolean	True if complete, otherwise not complete yet
 	 */
 	public function synchronize() {
-		for ($i = 0; $i < 200; $i++) {
+		for ($i = 0; $i < 5; $i++) {
 			if ($this->isComplete()) {
-				return;
+				return true;
 			}
-			usleep(500000);
+			usleep(1000000);
 		}
-		throw new AsyncRunnerException("Error: Long running process exceeded 100 seconds while waiting to synchronize");
+		return false;
 	}
 }
 

--- a/api/src/BundleHelper.php
+++ b/api/src/BundleHelper.php
@@ -6,6 +6,7 @@ class BundleHelper {
 	const State_Bundle      = 'Bundle';
 	const State_Downloading = 'Downloading';
 	const State_Uploading   = 'Uploading';
+	const State_Verify      = 'Verify';
 	const State_Unbundle    = 'Unbundle';
 
 	private $_transactionId;

--- a/api/src/BundleHelper.php
+++ b/api/src/BundleHelper.php
@@ -6,7 +6,7 @@ class BundleHelper {
 	const State_Bundle      = 'Bundle';
 	const State_Downloading = 'Downloading';
 	const State_Uploading   = 'Uploading';
-	const State_Verify      = 'Verify';
+	const State_Validating  = 'Validating';
 	const State_Unbundle    = 'Unbundle';
 
 	private $_transactionId;

--- a/api/src/HgResumeApi.php
+++ b/api/src/HgResumeApi.php
@@ -99,7 +99,7 @@ class HgResumeAPI {
 			// We got everything, fall through to completePushBundle
 			case BundleHelper::State_Validating:
 			case BundleHelper::State_Unbundle:
-				return $this->completePushBundle($bundle, $hg, $transId);
+				return $this->completePushBundle($bundle, $hg, $transId, $bundleSize);
 		}
 	}
 
@@ -112,7 +112,7 @@ class HgResumeAPI {
 	 * @throws Exception
 	 * @return HgResumeResponse
 	 */
-	function completePushBundle($bundle, $hg, $transId) {
+	function completePushBundle($bundle, $hg, $transId, $bundleSize) {
 		try {  // REVIEW Would be nice if the try / catch logic was universal. ie one policy for the api function. CP 2012-06
 			$bundleFilePath = $bundle->getBundleFileName();
 
@@ -126,7 +126,7 @@ class HgResumeAPI {
 						$bundle->setState(BundleHelper::State_Unbundle);
 						$hg->unbundle($bundleFilePath);
 					} else {
-						return new HgResumeResponse(HgResumeResponse::TIMEOUT, array('transId' => $transId, 'Note' => 'Verification in progress...'));
+						return HgResumeResponse::PendingResponse($transId, 'Verification in progress...', $bundleSize);
 					}
 					// fall through to State_Unbundle
 				case BundleHelper::State_Unbundle:
@@ -142,7 +142,7 @@ class HgResumeAPI {
 						$responseValues = array('transId' => $transId);
 						return new HgResumeResponse(HgResumeResponse::SUCCESS, $responseValues);
 					} else {
-						return new HgResumeResponse(HgResumeResponse::TIMEOUT, array('transId' => $transId, 'Note' => 'Unpacking in progress...'));
+						return HgResumeResponse::PendingResponse($transId, 'Unpacking in progress...', $bundleSize);
 					}
 				}
 		} catch (UnrelatedRepoException $e) {

--- a/api/src/HgResumeApi.php
+++ b/api/src/HgResumeApi.php
@@ -131,7 +131,7 @@ class HgResumeAPI {
 					// fall through to State_Unbundle
 				case BundleHelper::State_Unbundle:
 					$asyncRunner = new AsyncRunner($bundleFilePath);
-					if ($asyncRunner->synchronize()) {
+					if ($asyncRunner->waitForIsComplete()) {
 						if (BundleHelper::bundleOutputHasErrors($asyncRunner->getOutput())) {
 							$responseValues = array('transId' => $transId);
 							// REVIEW The RESET response may not make sense in this context anymore.  Why would we want to tell the client to resend a bundle if it failed the first time?  My guess is never.  cjh 2013-03

--- a/api/src/HgResumeResponse.php
+++ b/api/src/HgResumeResponse.php
@@ -61,6 +61,13 @@ class HgResumeResponse {
 	// HTTP 202 Accepted
 	const INPROGRESS = 9;
 
+	/* TIMEOUT
+	 * The server is in the middle of an operation that was not completed during the request.
+	 * The client should poll the server to ensure any additional operations are started.
+	 * Used only by pushBundleChunk */
+	// HTTP 408 RequestTimeout
+	const TIMEOUT = 9;
+
 	public $Code;
 	public $Values;
 	public $Content;

--- a/api/src/HgResumeResponse.php
+++ b/api/src/HgResumeResponse.php
@@ -79,6 +79,22 @@ class HgResumeResponse {
 		$this->Content = $content;
 		$this->Version = $version;
 	}
+
+	/**
+	 * There's no explicit polling mechanism in the v3 client.
+	 * But we can make it retry by sending any status code it's not familiar with.
+	 * We can also determine the chunk size the client will use, so we make it super tiny to minimize unnecessary data transfer.
+	 * @param string $transId
+	 * @param string $note
+	 * @param int $bundleSize
+	 * @return HgResumeResponse
+	 */
+	public static function PendingResponse($transId, $note, $bundleSize) {
+		return new HgResumeResponse(HgResumeResponse::TIMEOUT, array(
+			'transId' => $transId, 'Note' => $note,
+			// Make the client send only 10 bytes
+			'sow' => $bundleSize - 10));
+	}
 }
 
 ?>

--- a/api/src/HgRunner.php
+++ b/api/src/HgRunner.php
@@ -59,14 +59,14 @@ class HgRunner {
 	}
 
 	/**
-	 * @param AsyncRunner $asyncRunner
+	 * @param string $filepath
 	 * @throws UnrelatedRepoException
 	 * @throws Exception
 	 * @return boolean True if finished, otherwise not finished yet
 	 */
 	function finishValidating($filepath) {
 		$asyncRunner = $this->getValidationRunner($filepath);
-		if ($asyncRunner->synchronize()) {
+		if ($asyncRunner->waitForIsComplete()) {
 			$output = $asyncRunner->getOutput();
 			if (preg_match('/abort:.*unknown parent/', $output)) {
 				throw new UnrelatedRepoException("Project is unrelated!  (unrelated bundle pushed to repo)");
@@ -147,13 +147,15 @@ class HgRunner {
 	}
 
 	/**
-	 * helper function, mostly for tests
+	 * Helper function for tests
 	 * @param string $baseHashes[]
 	 * @param string $bundleFilePath
 	 */
 	function makeBundleAndWaitUntilFinished($baseHashes, $bundleFilePath) {
 		$asyncRunner = $this->makeBundle($baseHashes, $bundleFilePath);
-		$asyncRunner->synchronize();
+		if (!$asyncRunner->waitForIsComplete()) {
+			throw new Exception("Error: make bundle failed to complete");
+		}
 		return $asyncRunner;
 	}
 

--- a/api/src/HgRunner.php
+++ b/api/src/HgRunner.php
@@ -42,14 +42,10 @@ class HgRunner {
 	}
 
 	/**
-	 * 
 	 * @param string $filepath
 	 * @throws HgException
-	 * @throws UnrelatedRepoException
-	 * @throws Exception
-	 * @return AsyncRunner
 	 */
-	function unbundle($filepath) {
+	function startVerify($filepath) {
 		if (!is_file($filepath)) {
 			throw new HgException("bundle file '$filepath' is not a file!");
 		}
@@ -58,29 +54,59 @@ class HgRunner {
 		// run hg incoming to make sure this bundle is related to the repo
 		$cmd = "hg incoming $filepath";
 		$this->logEvent("cmd: $cmd");
-		$asyncRunner = new AsyncRunner($filepath . ".incoming");
+		$asyncRunner = $this->getVerifyRunner($filepath);
 		$asyncRunner->run($cmd);
-		$asyncRunner->synchronize();
-		$output = $asyncRunner->getOutput();
-		if (preg_match('/abort:.*unknown parent/', $output)) {
-			throw new UnrelatedRepoException("Project is unrelated!  (unrelated bundle pushed to repo)");
+	}
+
+	/**
+	 * @param AsyncRunner $asyncRunner
+	 * @throws UnrelatedRepoException
+	 * @throws Exception
+	 * @return boolean True if finished, otherwise not finished yet
+	 */
+	function completeVerify($filepath) {
+		$asyncRunner = $this->getVerifyRunner($filepath);
+		if ($asyncRunner->synchronize()) {
+			$output = $asyncRunner->getOutput();
+			if (preg_match('/abort:.*unknown parent/', $output)) {
+				throw new UnrelatedRepoException("Project is unrelated!  (unrelated bundle pushed to repo)");
+			}
+			if (preg_match('/parent:\s*-1:/', $output)) {
+				throw new UnrelatedRepoException("Project is unrelated!  (unrelated bundle pushed to repo)");
+			}
+			if (preg_match('/abort:.*not a Mercurial bundle/', $output)) {
+				throw new Exception("Project cannot be updated!  (corrupt bundle pushed to repo)");
+			}
+			return true;
 		}
-		if (preg_match('/parent:\s*-1:/', $output)) {
-			throw new UnrelatedRepoException("Project is unrelated!  (unrelated bundle pushed to repo)");
+		return false;
+	}
+
+	/**
+	 * @param string $filepath
+	 * @return AsyncRunner
+	 */
+	function getVerifyRunner($filepath) {
+		return new AsyncRunner($filepath . ".incoming");
+	}
+
+	/**
+	 * 
+	 * @param string $filepath
+	 * @throws HgException
+	 * @return AsyncRunner
+	 */
+	function unbundle($filepath) {
+		if (!is_file($filepath)) {
+			throw new HgException("bundle file '$filepath' is not a file!");
 		}
-		if (preg_match('/abort:.*not a Mercurial bundle/', $output)) {
-			throw new Exception("Project cannot be updated!  (corrupt bundle pushed to repo)");
-		}
+		chdir($this->repoPath); // NOTE: I tried with -R and it didn't work for me. CP 2012-06
 
 		$cmd = "hg unbundle $filepath";
 		$this->logEvent("cmd: $cmd");
 		$asyncRunner = new AsyncRunner($filepath);
 		$asyncRunner->run($cmd);
 		return $asyncRunner;
-	}
-	
-	function assertIsRelatedRepo($bundleFilePath) {
-		
 	}
 
 	/**

--- a/api/src/HgRunner.php
+++ b/api/src/HgRunner.php
@@ -45,7 +45,7 @@ class HgRunner {
 	 * @param string $filepath
 	 * @throws HgException
 	 */
-	function startVerify($filepath) {
+	function startValidating($filepath) {
 		if (!is_file($filepath)) {
 			throw new HgException("bundle file '$filepath' is not a file!");
 		}
@@ -54,7 +54,7 @@ class HgRunner {
 		// run hg incoming to make sure this bundle is related to the repo
 		$cmd = "hg incoming $filepath";
 		$this->logEvent("cmd: $cmd");
-		$asyncRunner = $this->getVerifyRunner($filepath);
+		$asyncRunner = $this->getValidationRunner($filepath);
 		$asyncRunner->run($cmd);
 	}
 
@@ -64,8 +64,8 @@ class HgRunner {
 	 * @throws Exception
 	 * @return boolean True if finished, otherwise not finished yet
 	 */
-	function completeVerify($filepath) {
-		$asyncRunner = $this->getVerifyRunner($filepath);
+	function finishValidating($filepath) {
+		$asyncRunner = $this->getValidationRunner($filepath);
 		if ($asyncRunner->synchronize()) {
 			$output = $asyncRunner->getOutput();
 			if (preg_match('/abort:.*unknown parent/', $output)) {
@@ -86,7 +86,7 @@ class HgRunner {
 	 * @param string $filepath
 	 * @return AsyncRunner
 	 */
-	function getVerifyRunner($filepath) {
+	function getValidationRunner($filepath) {
 		return new AsyncRunner($filepath . ".incoming");
 	}
 

--- a/api/src/RestServer.php
+++ b/api/src/RestServer.php
@@ -149,7 +149,7 @@ class RestServer {
 				break;
 			case HgResumeResponse::TIMEOUT:
 				// 408 is not currently handled by the client, so it will be
-				// interpreted as a fail and result in a retry
+				// interpreted as a fail and result in a retry. That is the intentional behaviour for now (v03).
 				$httpcode = "408 RequestTimeout";
 				$codeString = 'INPROGRESS';
 				break;

--- a/api/src/RestServer.php
+++ b/api/src/RestServer.php
@@ -147,6 +147,12 @@ class RestServer {
 				$httpcode = "202 Accepted";
 				$codeString = 'INPROGRESS';
 				break;
+			case HgResumeResponse::TIMEOUT:
+				// 408 is not currently handled by the client, so it will be
+				// interpreted as a fail and result in a retry
+				$httpcode = "408 RequestTimeout";
+				$codeString = 'INPROGRESS';
+				break;
 			default:
 				throw new Exception("Unknown response code {$response->Code}");
 				break;

--- a/api/test/AsyncRunner_Test.php
+++ b/api/test/AsyncRunner_Test.php
@@ -10,7 +10,7 @@ class TestOfAsyncRunner extends UnitTestCase {
 		$runner = new AsyncRunner('/tmp/testFile');
 		$runner->run('echo foo');
 		$this->assertFalse($runner->isComplete());
-		$runner->synchronize();
+		$runner->waitForIsComplete();
 		$this->assertTrue($runner->isComplete());
 	}
 
@@ -47,7 +47,8 @@ class TestOfAsyncRunner extends UnitTestCase {
 	function testGetOutput_Complete_ReturnsOutput() {
 		$runner = new AsyncRunner('/tmp/testFile');
 		$runner->run('echo abort');
-		$runner->synchronize();
+		$runner->waitForIsComplete();
+		$this->assertTrue($runner->isComplete());
 		$data = $runner->getOutput();
 		$this->assertPattern('/abort/', $data);
 	}

--- a/api/test/HgResumeApi_Test.php
+++ b/api/test/HgResumeApi_Test.php
@@ -493,6 +493,42 @@ class TestOfHgResumeAPI extends UnitTestCase {
 		$response = $this->api->pushBundleChunk('sampleHgRepo', $bundleSize, 0, $bundleData, $transId);
 		$this->assertEqual(HgResumeResponse::FAIL, $response->Code);
 	}
+	
+	function testPushBundleChunk_lastChunkTimesoutDuringHgIncoming_IsPickedUpByFollowUpRequest() {
+		$this->testEnvironment->makeRepo(TestPath . "/data/sampleHgRepo.zip");
+		$transId = __FUNCTION__;
+		$this->api->finishPushBundle($transId);
+
+		$bundleData = file_get_contents(TestPath . "/data/sample.bundle");
+
+		// Simulate a request timeout during hg unbundle
+		$this->pushFullBundle_KillDuringHgUnbundle('sampleHgRepo', $bundleData, $transId);
+
+		// Ensure that a follow up pushBundle successfully completes the unbundle
+		$bundleSize = mb_strlen($bundleData, "8bit");
+		$response = $this->api->pushBundleChunk('sampleHgRepo', $bundleSize, 0, $bundleData, $transId);
+		$this->assertEqual(HgResumeResponse::SUCCESS, $response->Code);
+	}
+
+	function pushFullBundle_KillDuringHgUnbundle($repoId, $bundleData, $transId) {
+		// fork a child process so we can kill unfinished work
+		$pid = pcntl_fork();
+
+		if ($pid == -1) {
+				throw new Exception('Failed to fork');
+		} elseif ($pid) { // PARENT
+				// Wait until hg incoming has started running
+				// it starts almost instantly and takes at least 500ms to run, because 500ms is the length of AsyncRunner's synchronize interval
+				usleep(250 * 1000);
+				// Kill so that nothing happens when hg incoming is done
+				posix_kill($pid, SIGTERM);
+		} else { // CHILD
+			$bundleSize = mb_strlen($bundleData, "8bit");
+			// push the entire bundle so that hg incoming is triggered
+			$response = $this->api->pushBundleChunk($repoId, $bundleSize, 0, $bundleData, $transId);
+			throw new Exception("The child process was protected by its buggy shield of digital faithlessness.");
+		}
+	}
 }
 
 ?>

--- a/api/test/HgResumeApi_Test.php
+++ b/api/test/HgResumeApi_Test.php
@@ -515,17 +515,17 @@ class TestOfHgResumeAPI extends UnitTestCase {
 		$pid = pcntl_fork();
 
 		if ($pid == -1) {
-				throw new Exception('Failed to fork');
+			throw new Exception('Failed to fork');
 		} elseif ($pid) { // PARENT
-				// Wait until hg incoming has started running
-				// it starts almost instantly and takes at least 500ms to run, because 500ms is the length of AsyncRunner's synchronize interval
-				usleep(250 * 1000);
-				// Kill so that nothing happens when hg incoming is done
-				posix_kill($pid, SIGTERM);
+			// Wait until hg incoming has started running
+			// it starts almost instantly and takes at least 500ms to run, because 500ms is the length of AsyncRunner's synchronize interval
+			usleep(250 * 1000);
+			// Kill so that nothing happens when hg incoming is done
+			posix_kill($pid, SIGTERM);
 		} else { // CHILD
 			$bundleSize = mb_strlen($bundleData, "8bit");
 			// push the entire bundle so that hg incoming is triggered
-			$response = $this->api->pushBundleChunk($repoId, $bundleSize, 0, $bundleData, $transId);
+			$this->api->pushBundleChunk($repoId, $bundleSize, 0, $bundleData, $transId);
 			throw new Exception("The child process was protected by its buggy shield of digital faithlessness.");
 		}
 	}

--- a/api/test/HgResumeApi_Test.php
+++ b/api/test/HgResumeApi_Test.php
@@ -279,7 +279,7 @@ class TestOfHgResumeAPI extends UnitTestCase {
 
 		$assembledBundle = '';
 		$bundleSize = 1; // initialize the bundleSize; it will be overwritten after the first API call
-		while (mb_strlen($assembledBundle) < $bundleSize) {
+		while (mb_strlen($assembledBundle, "8bit") < $bundleSize) {
 			$response = $this->api->pullBundleChunkInternal('sampleHgRepo2', array($hash), $offset, $chunkSize, $transId, true);
 			$this->assertEqual(HgResumeResponse::SUCCESS, $response->Code);
 			$bundleSize = $response->Values['bundleSize'];
@@ -302,7 +302,7 @@ class TestOfHgResumeAPI extends UnitTestCase {
 
 		$assembledBundle = '';
 		$bundleSize = 1; // initialize the bundleSize; it will be overwritten after the first API call
-		while (mb_strlen($assembledBundle) < $bundleSize) {
+		while (mb_strlen($assembledBundle, "8bit") < $bundleSize) {
 			$response = $this->api->pullBundleChunkInternal('sample2branchHgRepo', array($hash), $offset, $chunkSize, $transId, true);
 			$this->assertEqual(HgResumeResponse::SUCCESS, $response->Code);
 			$bundleSize = $response->Values['bundleSize'];
@@ -326,7 +326,7 @@ class TestOfHgResumeAPI extends UnitTestCase {
 
 		$assembledBundle = '';
 		$bundleSize = 1; // initialize the bundleSize; it will be overwritten after the first API call
-		while (mb_strlen($assembledBundle) < $bundleSize) {
+		while (mb_strlen($assembledBundle, "8bit") < $bundleSize) {
 			$response = $this->api->pullBundleChunkInternal('sample2branchHgRepo', $hashes, $offset, $chunkSize, $transId, true);
 			$this->assertEqual(HgResumeResponse::SUCCESS, $response->Code);
 			$bundleSize = $response->Values['bundleSize'];
@@ -426,7 +426,7 @@ class TestOfHgResumeAPI extends UnitTestCase {
 
 		$assembledBundle = '';
 		$bundleSize = 1; // initialize the bundleSize; it will be overwritten after the first API call
-		while (mb_strlen($assembledBundle) < $bundleSize) {
+		while (mb_strlen($assembledBundle, "8bit") < $bundleSize) {
 			$response = $this->api->pullBundleChunkInternal('sampleHgRepo2', array($hash), $offset, $chunkSize, $transId, true);
 			$this->assertEqual(HgResumeResponse::SUCCESS, $response->Code);
 			$bundleSize = $response->Values['bundleSize'];

--- a/api/test/HgRunner_Test.php
+++ b/api/test/HgRunner_Test.php
@@ -36,10 +36,12 @@ class TestOfHgRunner extends UnitTestCase {
 		// check for success file
 		$hg = new HgRunner($repoPath);
 		$asyncRunner = $hg->unbundle($bundleFile);
-		$asyncRunner->synchronize();
+		$asyncRunner->waitForIsComplete();
+		$this->assertTrue($asyncRunner->isComplete());
 		$asyncRunner->cleanUp();
 		$asyncRunner = $hg->update();
-		$asyncRunner->synchronize();
+		$asyncRunner->waitForIsComplete();
+		$this->assertTrue($asyncRunner->isComplete());
 		$this->assertTrue(file_exists($successFile));
 	}
 


### PR DESCRIPTION
If a request times out while `hg incoming` is running, the server assumes that `hg unbundle` has started, but it hasn't.
So, this PR introduces a new state (validate) to better keep track of what the next server-side step is and be more forgiving in that way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hgresume/12)
<!-- Reviewable:end -->
